### PR TITLE
Add statement upload wizard

### DIFF
--- a/components/dashboard/StatementUploadModal.tsx
+++ b/components/dashboard/StatementUploadModal.tsx
@@ -1,0 +1,92 @@
+import { useState } from 'react';
+import { fetchApi } from '../../lib/api-utils';
+
+export interface ParsedStatement {
+  recordType: 'asset' | 'debt';
+  asset?: any;
+  debt?: any;
+}
+
+interface Props {
+  onClose: () => void;
+  onParsed: (data: ParsedStatement) => void;
+}
+
+const StatementUploadModal = ({ onClose, onParsed }: Props) => {
+  const [file, setFile] = useState<File | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isUploading, setIsUploading] = useState(false);
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const selected = e.target.files?.[0];
+    if (!selected) return;
+    if (selected.type !== 'application/pdf') {
+      setError('Only PDF files are allowed');
+      return;
+    }
+    setFile(selected);
+    setError(null);
+  };
+
+  const fileToBase64 = (file: File): Promise<string> => {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => {
+        const result = reader.result as string;
+        const base64 = result.split(',')[1];
+        resolve(base64);
+      };
+      reader.onerror = reject;
+      reader.readAsDataURL(file);
+    });
+  };
+
+  const handleUpload = async () => {
+    if (!file) return;
+    setIsUploading(true);
+    try {
+      const base64 = await fileToBase64(file);
+      const response = await fetchApi<ParsedStatement>('/api/statement-upload', {
+        method: 'POST',
+        body: JSON.stringify({ filename: file.name, file: base64 }),
+      });
+      if (response.success && response.data) {
+        onParsed(response.data);
+        onClose();
+      } else {
+        setError(response.error || 'Failed to process statement');
+      }
+    } catch (err: any) {
+      setError(err.message || 'Upload failed');
+    } finally {
+      setIsUploading(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <input type="file" accept="application/pdf" onChange={handleFileChange} />
+      {error && <p className="text-sm text-red-500">{error}</p>}
+      <div className="flex justify-end space-x-3">
+        <button
+          type="button"
+          onClick={onClose}
+          className="btn"
+          disabled={isUploading}
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          onClick={handleUpload}
+          className="btn btn-primary"
+          disabled={!file || isUploading}
+        >
+          {isUploading ? 'Uploading...' : 'Upload'}
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default StatementUploadModal;

--- a/pages/api/statement-upload.ts
+++ b/pages/api/statement-upload.ts
@@ -1,0 +1,78 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { createApiHandler, ApiResponse, authenticate } from '../../lib/api-utils';
+import { GoogleGenerativeAI, HarmCategory, HarmBlockThreshold } from '@google/generative-ai';
+import fs from 'fs';
+import path from 'path';
+
+interface ParsedStatement {
+  recordType: 'asset' | 'debt';
+  asset?: any;
+  debt?: any;
+}
+
+const MODEL_NAME = 'gemini-2.5-flash-preview-04-17';
+const API_KEY = process.env.GEMINI_API_KEY;
+
+async function analyzeWithGemini(filePath: string): Promise<ParsedStatement> {
+  if (!API_KEY) throw new Error('Gemini API key not configured');
+  const genAI = new GoogleGenerativeAI(API_KEY);
+  const model = genAI.getGenerativeModel({ model: MODEL_NAME });
+  const fileData = await fs.promises.readFile(filePath);
+
+  const prompt = `You are a financial document analysis assistant. A user has uploaded a financial statement in PDF format. Determine whether the statement represents an asset or a liability. Extract the account balance.\nIf it is an asset identify if it is cash or an investment. If it is cash provide the interest rate if available. If it is an investment provide the split between stocks and bonds, a risk level of Low, Medium, or High, and an expected rate of return based on that risk.\nIf it is a liability provide the minimum monthly payment and the interest rate.\nReturn a JSON object with the following structure:\n{recordType: 'asset'|'debt', asset?: {type:'Cash'|'Investment', subtype?:string, name?:string, balance:number, interestRate?:number, allocation?:{stocks:number,bonds:number}, riskLevel?:'Low'|'Medium'|'High', expectedReturn?:number}, debt?:{type?:string,lender?:string,balance:number,interestRate?:number,minimumPayment?:number}}`;
+
+  const result = await model.generateContent({
+    contents: [
+      {
+        role: 'user',
+        parts: [
+          { text: prompt },
+          { inlineData: { data: fileData.toString('base64'), mimeType: 'application/pdf' } },
+        ],
+      },
+    ],
+    generationConfig: { temperature: 0.2, maxOutputTokens: 1024 },
+    safetySettings: [
+      { category: HarmCategory.HARM_CATEGORY_HARASSMENT, threshold: HarmBlockThreshold.BLOCK_MEDIUM_AND_ABOVE },
+      { category: HarmCategory.HARM_CATEGORY_HATE_SPEECH, threshold: HarmBlockThreshold.BLOCK_MEDIUM_AND_ABOVE },
+      { category: HarmCategory.HARM_CATEGORY_SEXUALLY_EXPLICIT, threshold: HarmBlockThreshold.BLOCK_MEDIUM_AND_ABOVE },
+      { category: HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT, threshold: HarmBlockThreshold.BLOCK_MEDIUM_AND_ABOVE },
+    ],
+  });
+
+  const text = result.response.text();
+  return JSON.parse(text);
+}
+
+export default createApiHandler<ParsedStatement>(async (
+  req: NextApiRequest,
+  res: NextApiResponse<ApiResponse<ParsedStatement>>
+) => {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ success: false, error: 'Method not allowed' });
+  }
+
+  const userId = await authenticate(req);
+
+  const { file, filename } = req.body as { file?: string; filename?: string };
+  if (!file || !filename) {
+    return res.status(400).json({ success: false, error: 'File is required' });
+  }
+  if (!filename.toLowerCase().endsWith('.pdf')) {
+    return res.status(400).json({ success: false, error: 'Only PDF files are allowed' });
+  }
+
+  const buffer = Buffer.from(file, 'base64');
+  const tempPath = path.join('/tmp', `${userId}-${Date.now()}-${filename}`);
+  await fs.promises.writeFile(tempPath, buffer);
+
+  try {
+    const parsed = await analyzeWithGemini(tempPath);
+    return res.status(200).json({ success: true, data: parsed });
+  } catch (error: any) {
+    console.error('Statement upload error:', error);
+    return res.status(500).json({ success: false, error: error.message || 'Failed to analyze statement' });
+  } finally {
+    fs.promises.unlink(tempPath).catch(() => {});
+  }
+});


### PR DESCRIPTION
## Summary
- create API endpoint to process PDF statements via Gemini
- add statement upload modal component
- integrate statement upload flow on asset and debt pages

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: tsc errors and missing deps)*
- `npm test` *(fails: jest not found)*