### PR TITLE
Add statement review feature and persistent uploads

### DIFF
--- a/__tests__/review.test.ts
+++ b/__tests__/review.test.ts
@@ -1,0 +1,15 @@
+import handler from '../pages/api/review/[recordType]';
+
+const createMocks = () => {
+  const req: any = { method: 'GET', query: { recordType: 'asset' }, body: {}, headers: {} };
+  const res: any = { status: jest.fn(() => res), json: jest.fn(() => res) };
+  return { req, res };
+};
+
+describe('review api', () => {
+  it('rejects non-POST', async () => {
+    const { req, res } = createMocks();
+    await (handler as any)(req, res);
+    expect(res.status).toHaveBeenCalledWith(405);
+  });
+});

--- a/__tests__/statement-upload.test.ts
+++ b/__tests__/statement-upload.test.ts
@@ -1,0 +1,15 @@
+import handler from '../pages/api/statement-upload';
+
+const createMocks = () => {
+  const req: any = { method: 'GET', body: {}, headers: {} };
+  const res: any = { status: jest.fn(() => res), json: jest.fn(() => res) };
+  return { req, res };
+};
+
+describe('statement-upload', () => {
+  it('rejects non-POST', async () => {
+    const { req, res } = createMocks();
+    await (handler as any)(req, res);
+    expect(res.status).toHaveBeenCalledWith(405);
+  });
+});

--- a/components/dashboard/AssetForm.tsx
+++ b/components/dashboard/AssetForm.tsx
@@ -98,6 +98,11 @@ const AssetForm = ({ onSubmit, onCancel, initialValues, isSubmitting }: AssetFor
       annualContribution: formData.annualContribution ? parseFloat(formData.annualContribution) : null,
       growthRate: formData.growthRate ? parseFloat(formData.growthRate) : null,
     };
+
+    if (initialValues?.statementPath) {
+      (assetData as any).statementPath = initialValues.statementPath;
+      (assetData as any).statementName = initialValues.statementName;
+    }
     
     onSubmit(assetData);
   };

--- a/components/dashboard/DebtForm.tsx
+++ b/components/dashboard/DebtForm.tsx
@@ -90,6 +90,11 @@ const DebtForm = ({ onSubmit, onCancel, initialValues, isSubmitting }: DebtFormP
       monthlyPayment: parseFloat(formData.monthlyPayment),
       termLength: formData.termLength ? parseInt(formData.termLength) : null,
     };
+
+    if (initialValues?.statementPath) {
+      (debtData as any).statementPath = initialValues.statementPath;
+      (debtData as any).statementName = initialValues.statementName;
+    }
     
     onSubmit(debtData);
   };

--- a/components/dashboard/ReviewButton.tsx
+++ b/components/dashboard/ReviewButton.tsx
@@ -1,0 +1,12 @@
+import { useState } from 'react';
+import ReviewModal from './ReviewModal';
+
+export default function ReviewButton({ recordType, record }: { recordType: 'asset' | 'debt'; record: any; }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <button className="text-green-600 hover:text-green-900" onClick={() => setOpen(true)}>Review</button>
+      <ReviewModal isOpen={open} onClose={() => setOpen(false)} recordType={recordType} record={record} />
+    </>
+  );
+}

--- a/components/dashboard/ReviewModal.tsx
+++ b/components/dashboard/ReviewModal.tsx
@@ -1,0 +1,82 @@
+import { useState, useEffect, useRef } from 'react';
+import Modal from '../layout/Modal';
+import { fetchApi } from '../../lib/api-utils';
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+  recordType: 'asset' | 'debt';
+  record: any;
+}
+
+interface Message {
+  id: string;
+  sender: 'user' | 'ai';
+  text: string;
+}
+
+export default function ReviewModal({ isOpen, onClose, recordType, record }: Props) {
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [input, setInput] = useState('');
+  const [loading, setLoading] = useState(false);
+  const endRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (isOpen) {
+      setMessages([]);
+      setInput('');
+      fetchInitial();
+    }
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (endRef.current) endRef.current.scrollIntoView({ behavior: 'smooth' });
+  }, [messages]);
+
+  const fetchInitial = async () => {
+    setLoading(true);
+    const res = await fetchApi<string>(`/api/review/${recordType}`, {
+      method: 'POST',
+      body: JSON.stringify({ record })
+    });
+    const text = res.success && res.data ? res.data : res.error || 'Error';
+    setMessages([{ id: Date.now().toString(), sender: 'ai', text }]);
+    setLoading(false);
+  };
+
+  const sendMessage = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!input.trim()) return;
+    const userMsg: Message = { id: Date.now().toString(), sender: 'user', text: input };
+    setMessages(prev => [...prev, userMsg]);
+    const current = input;
+    setInput('');
+    setLoading(true);
+    const res = await fetchApi<string>(`/api/review/${recordType}`, {
+      method: 'POST',
+      body: JSON.stringify({ record, message: current })
+    });
+    const text = res.success && res.data ? res.data : res.error || 'Error';
+    setMessages(prev => [...prev, { id: (Date.now()+1).toString(), sender: 'ai', text }]);
+    setLoading(false);
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="AI Review" maxWidth="max-w-xl">
+      <div className="flex h-80 flex-col">
+        <div className="flex-1 overflow-y-auto space-y-2">
+          {messages.map(m => (
+            <div key={m.id} className={m.sender === 'user' ? 'text-right' : 'text-left'}>
+              <span className={`inline-block rounded px-3 py-2 ${m.sender === 'user' ? 'bg-primary text-white' : 'bg-gray-200 text-gray-800'}`}>{m.text}</span>
+            </div>
+          ))}
+          <div ref={endRef} />
+        </div>
+        <form onSubmit={sendMessage} className="mt-2 flex gap-2">
+          <input className="flex-1 rounded border px-2" value={input} onChange={e => setInput(e.target.value)} />
+          <button type="submit" className="btn btn-primary" disabled={loading}>Send</button>
+        </form>
+      </div>
+    </Modal>
+  );
+}

--- a/components/dashboard/StatementUploadModal.tsx
+++ b/components/dashboard/StatementUploadModal.tsx
@@ -1,10 +1,34 @@
 import { useState } from 'react';
 import { fetchApi } from '../../lib/api-utils';
 
+export interface AssetData {
+  type: string;
+  subtype?: string;
+  name: string;
+  balance: number;
+  interestRate?: number;
+  annualContribution?: number;
+  growthRate?: number;
+  assetClass?: string;
+  statementPath?: string;
+  statementName?: string;
+}
+
+export interface DebtData {
+  type: string;
+  lender: string;
+  balance: number;
+  interestRate: number;
+  monthlyPayment: number;
+  termLength?: number;
+  statementPath?: string;
+  statementName?: string;
+}
+
 export interface ParsedStatement {
-  recordType: 'asset' | 'debt';
-  asset?: any;
-  debt?: any;
+  recordType: 'asset' | 'debt' | null;
+  asset?: AssetData;
+  debt?: DebtData;
 }
 
 interface Props {

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.(ts|tsx)$': 'ts-jest'
+  }
+};

--- a/pages/api/dashboard/assets.ts
+++ b/pages/api/dashboard/assets.ts
@@ -29,7 +29,7 @@ export default createApiHandler<Asset | Asset[]>(async (
 
   // POST: create new asset
   if (req.method === 'POST') {
-    const { type, subtype, name, balance, interestRate, annualContribution, growthRate, assetClass } = req.body;
+    const { type, subtype, name, balance, interestRate, annualContribution, growthRate, assetClass, statementPath, statementName } = req.body;
     if (!type || !name || balance === undefined) {
       return res.status(400).json({ success: false, error: 'Type, name, and balance are required' });
     }
@@ -44,6 +44,8 @@ export default createApiHandler<Asset | Asset[]>(async (
         annualContribution: annualContribution !== undefined ? parseFloat(annualContribution) : null,
         growthRate: growthRate !== undefined ? parseFloat(growthRate) : null,
         assetClass,
+        statementPath,
+        statementName,
       },
     });
     return res.status(201).json({ success: true, data: asset });
@@ -59,7 +61,7 @@ export default createApiHandler<Asset | Asset[]>(async (
     if (!existing || existing.userId !== userId) {
       return res.status(404).json({ success: false, error: 'Asset not found' });
     }
-    const { type, subtype, name, balance, interestRate, annualContribution, growthRate, assetClass } = req.body;
+    const { type, subtype, name, balance, interestRate, annualContribution, growthRate, assetClass, statementPath, statementName } = req.body;
     const updated = await prisma.asset.update({
       where: { id: id as string },
       data: {
@@ -71,6 +73,8 @@ export default createApiHandler<Asset | Asset[]>(async (
         annualContribution: annualContribution !== undefined ? parseFloat(annualContribution) : existing.annualContribution,
         growthRate: growthRate !== undefined ? parseFloat(growthRate) : existing.growthRate,
         assetClass: assetClass ?? existing.assetClass,
+        statementPath: statementPath ?? existing.statementPath,
+        statementName: statementName ?? existing.statementName,
       },
     });
     return res.status(200).json({ success: true, data: updated });

--- a/pages/api/dashboard/debts.ts
+++ b/pages/api/dashboard/debts.ts
@@ -23,7 +23,7 @@ export default createApiHandler<Debt | Debt[]>(async (
   }
 
   if (req.method === 'POST') {
-    const { type, lender, balance, interestRate, monthlyPayment, termLength } = req.body;
+    const { type, lender, balance, interestRate, monthlyPayment, termLength, statementPath, statementName } = req.body;
     if (!type || !lender || balance === undefined || interestRate === undefined || monthlyPayment === undefined) {
       return res.status(400).json({ success: false, error: 'Type, lender, balance, interest rate, and monthly payment are required' });
     }
@@ -36,6 +36,8 @@ export default createApiHandler<Debt | Debt[]>(async (
         interestRate: parseFloat(interestRate),
         monthlyPayment: parseFloat(monthlyPayment),
         termLength: termLength !== undefined ? (termLength ? parseInt(termLength, 10) : null) : null,
+        statementPath,
+        statementName,
       },
     });
     return res.status(201).json({ success: true, data: debt });
@@ -50,7 +52,7 @@ export default createApiHandler<Debt | Debt[]>(async (
     if (!existing || existing.userId !== userId) {
       return res.status(404).json({ success: false, error: 'Debt not found' });
     }
-    const { type, lender, balance, interestRate, monthlyPayment, termLength } = req.body;
+    const { type, lender, balance, interestRate, monthlyPayment, termLength, statementPath, statementName } = req.body;
     const updated = await prisma.debt.update({
       where: { id: id as string },
       data: {
@@ -60,6 +62,8 @@ export default createApiHandler<Debt | Debt[]>(async (
         interestRate: interestRate !== undefined ? parseFloat(interestRate) : existing.interestRate,
         monthlyPayment: monthlyPayment !== undefined ? parseFloat(monthlyPayment) : existing.monthlyPayment,
         termLength: termLength !== undefined ? (termLength ? parseInt(termLength, 10) : null) : existing.termLength,
+        statementPath: statementPath ?? existing.statementPath,
+        statementName: statementName ?? existing.statementName,
       },
     });
     return res.status(200).json({ success: true, data: updated });

--- a/pages/api/review/[recordType].ts
+++ b/pages/api/review/[recordType].ts
@@ -1,0 +1,71 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { createApiHandler, ApiResponse, authenticate } from '../../../lib/api-utils';
+import { GoogleGenerativeAI, HarmCategory, HarmBlockThreshold } from '@google/generative-ai';
+import fs from 'fs';
+import path from 'path';
+
+interface ReviewRequest {
+  record: any;
+  message?: string;
+}
+
+const MODEL_NAME = 'gemini-2.5-flash-preview-04-17';
+const API_KEY = process.env.GEMINI_API_KEY;
+
+export default createApiHandler<string>(async (
+  req: NextApiRequest,
+  res: NextApiResponse<ApiResponse<string>>
+) => {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ success: false, error: 'Method not allowed' });
+  }
+
+  if (!API_KEY) {
+    return res.status(500).json({ success: false, error: 'AI service not configured' });
+  }
+
+  const userId = await authenticate(req);
+  const { recordType } = req.query;
+  if (recordType !== 'asset' && recordType !== 'debt') {
+    return res.status(400).json({ success: false, error: 'Invalid record type' });
+  }
+
+  const { record, message } = req.body as ReviewRequest;
+  if (!record) {
+    return res.status(400).json({ success: false, error: 'Record data is required' });
+  }
+
+  const genAI = new GoogleGenerativeAI(API_KEY);
+  const model = genAI.getGenerativeModel({ model: MODEL_NAME });
+
+  let pdfPart;
+  if (record.statementPath) {
+    const abs = path.join(process.cwd(), 'public', record.statementPath);
+    try {
+      const data = await fs.promises.readFile(abs);
+      pdfPart = { inlineData: { data: data.toString('base64'), mimeType: 'application/pdf' } };
+    } catch {
+      // ignore missing file
+    }
+  }
+
+  const prompt = `You are PocketFA helping a user review a ${recordType}. Here is the JSON data:\n${JSON.stringify(record)}\n${message ? 'User question: '+message : 'Provide a brief analysis and recommendations.'}`;
+
+  const result = await model.generateContent({
+    contents: [
+      {
+        role: 'user',
+        parts: pdfPart ? [pdfPart, { text: prompt }] : [{ text: prompt }]
+      }
+    ],
+    generationConfig: { temperature: 0.4, maxOutputTokens: 1024 },
+    safetySettings: [
+      { category: HarmCategory.HARM_CATEGORY_HARASSMENT, threshold: HarmBlockThreshold.BLOCK_MEDIUM_AND_ABOVE },
+      { category: HarmCategory.HARM_CATEGORY_HATE_SPEECH, threshold: HarmBlockThreshold.BLOCK_MEDIUM_AND_ABOVE },
+      { category: HarmCategory.HARM_CATEGORY_SEXUALLY_EXPLICIT, threshold: HarmBlockThreshold.BLOCK_MEDIUM_AND_ABOVE },
+      { category: HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT, threshold: HarmBlockThreshold.BLOCK_MEDIUM_AND_ABOVE }
+    ]
+  });
+
+  return res.status(200).json({ success: true, data: result.response.text() });
+});

--- a/pages/dashboard/assets/index.tsx
+++ b/pages/dashboard/assets/index.tsx
@@ -6,6 +6,7 @@ import Modal from '../../../components/layout/Modal';
 import AssetForm from '../../../components/dashboard/AssetForm';
 import DebtForm from '../../../components/dashboard/DebtForm';
 import StatementUploadModal, { ParsedStatement } from '../../../components/dashboard/StatementUploadModal';
+import ReviewButton from '../../../components/dashboard/ReviewButton';
 import { NextPageWithLayout } from '../../_app';
 import { useAuth } from '../../../hooks/useAuth';
 import { fetchApi } from '../../../lib/api-utils';
@@ -311,7 +312,11 @@ const Assets: NextPageWithLayout = () => {
                                 Edit
                               </button>
                               <span className="mx-2 text-gray-300">|</span>
-                              <button 
+                              <ReviewButton recordType="asset" record={asset} />
+                              <span className="mx-2 text-gray-300">|</span>
+                              <ReviewButton recordType="asset" record={asset} />
+                              <span className="mx-2 text-gray-300">|</span>
+                              <button
                                 className="text-red-600 hover:text-red-900"
                                 onClick={() => {
                                   setAssetToDelete(asset);

--- a/pages/dashboard/debts/index.tsx
+++ b/pages/dashboard/debts/index.tsx
@@ -6,6 +6,7 @@ import Modal from '../../../components/layout/Modal';
 import DebtForm from '../../../components/dashboard/DebtForm';
 import AssetForm from '../../../components/dashboard/AssetForm';
 import StatementUploadModal, { ParsedStatement } from '../../../components/dashboard/StatementUploadModal';
+import ReviewButton from '../../../components/dashboard/ReviewButton';
 import { NextPageWithLayout } from '../../_app';
 import { useAuth } from '../../../hooks/useAuth';
 import { fetchApi } from '../../../lib/api-utils';
@@ -321,7 +322,9 @@ const Debts: NextPageWithLayout = () => {
                                 Edit
                               </button>
                               <span className="mx-2 text-gray-300">|</span>
-                              <button 
+                              <ReviewButton recordType="debt" record={debt} />
+                              <span className="mx-2 text-gray-300">|</span>
+                              <button
                                 className="text-red-600 hover:text-red-900"
                                 onClick={() => {
                                   setDebtToDelete(debt);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -54,6 +54,8 @@ model Asset {
   annualContribution Float?
   growthRate       Float?
   assetClass       String?  // "Stocks", "Bonds", "ETFs", "Mutual Funds"
+  statementPath    String?
+  statementName    String?
   createdAt        DateTime @default(now())
   updatedAt        DateTime @updatedAt
 }
@@ -68,6 +70,8 @@ model Debt {
   interestRate     Float
   monthlyPayment   Float
   termLength       Int?     // in months
+  statementPath    String?
+  statementName    String?
   createdAt        DateTime @default(now())
   updatedAt        DateTime @updatedAt
 }


### PR DESCRIPTION
## Summary
- parse uploaded statements into asset/debt fields
- save uploaded PDF path and return it with parsed data
- extend Prisma models with optional statement fields
- add API endpoint for per-record AI review
- provide ReviewButton and ReviewModal components
- show Review buttons on asset and debt tables
- add minimal jest config and endpoint tests

## Testing
- `npx prisma migrate dev --name add-statement-fields --skip-seed` *(fails: EHOSTUNREACH)*
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails with module errors)*
- `npm test` *(fails: jest not found)*