### PR TITLE
Improve chat markdown and context snapshot

### DIFF
--- a/components/dashboard/ChatInterface.tsx
+++ b/components/dashboard/ChatInterface.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef, useEffect } from 'react';
+import ReactMarkdown from 'react-markdown';
 import { motion, AnimatePresence } from 'framer-motion';
 import { fetchApi } from '../../lib/api-utils'; // Add this import
 
@@ -36,6 +37,27 @@ export default function ChatInterface() {
       messagesEndRef.current.scrollIntoView({ behavior: 'smooth' });
     }
   }, [messages]);
+
+  // Fetch initial snapshot when chat is opened
+  useEffect(() => {
+    if (isOpen) {
+      (async () => {
+        const response = await fetchApi<{ message: string }>('/api/chat', {
+          method: 'POST',
+          body: JSON.stringify({ message: '__init__' }),
+        });
+        if (response.success && response.data) {
+          const aiMessage: Message = {
+            id: Date.now().toString(),
+            sender: 'ai',
+            text: response.data.message,
+            timestamp: new Date(),
+          };
+          setMessages([INITIAL_MESSAGES[0], aiMessage]);
+        }
+      })();
+    }
+  }, [isOpen]);
 
   const handleSendMessage = async (e?: React.FormEvent) => { // Make this async
     if (e) e.preventDefault();
@@ -157,10 +179,11 @@ export default function ChatInterface() {
                       message.sender === 'user'
                         ? 'bg-primary text-white'
                         : 'bg-gray-200 text-gray-800'
-                    }`}
-                    style={{ maxWidth: '80%' }}
+                    } max-w-full`}
                   >
-                    <p className="text-sm">{message.text}</p>
+                    <ReactMarkdown className="prose whitespace-pre-wrap break-words text-sm">
+                      {message.text}
+                    </ReactMarkdown>
                     <p className="mt-1 text-right text-xs opacity-70">
                       {message.timestamp.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
                     </p>

--- a/components/dashboard/ReviewModal.tsx
+++ b/components/dashboard/ReviewModal.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef } from 'react';
+import ReactMarkdown from 'react-markdown';
 import Modal from '../layout/Modal';
 import { fetchApi } from '../../lib/api-utils';
 
@@ -67,7 +68,11 @@ export default function ReviewModal({ isOpen, onClose, recordType, record }: Pro
         <div className="flex-1 overflow-y-auto space-y-2">
           {messages.map(m => (
             <div key={m.id} className={m.sender === 'user' ? 'text-right' : 'text-left'}>
-              <span className={`inline-block rounded px-3 py-2 ${m.sender === 'user' ? 'bg-primary text-white' : 'bg-gray-200 text-gray-800'}`}>{m.text}</span>
+              <div className={`inline-block rounded px-3 py-2 ${m.sender === 'user' ? 'bg-primary text-white' : 'bg-gray-200 text-gray-800'} max-w-full`}>
+                <ReactMarkdown className="prose whitespace-pre-wrap break-words text-sm">
+                  {m.text}
+                </ReactMarkdown>
+              </div>
             </div>
           ))}
           <div ref={endRef} />

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "next": "^14.1.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-markdown": "^9.0.7",
     "zustand": "^4.5.2",
     "speakeasy": "^2.0.0"
   },

--- a/pages/api/review/[recordType].ts
+++ b/pages/api/review/[recordType].ts
@@ -60,10 +60,10 @@ export default createApiHandler<string>(async (
     ],
     generationConfig: { temperature: 0.4, maxOutputTokens: 1024 },
     safetySettings: [
-      { category: HarmCategory.HARM_CATEGORY_HARASSMENT, threshold: HarmBlockThreshold.BLOCK_MEDIUM_AND_ABOVE },
-      { category: HarmCategory.HARM_CATEGORY_HATE_SPEECH, threshold: HarmBlockThreshold.BLOCK_MEDIUM_AND_ABOVE },
-      { category: HarmCategory.HARM_CATEGORY_SEXUALLY_EXPLICIT, threshold: HarmBlockThreshold.BLOCK_MEDIUM_AND_ABOVE },
-      { category: HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT, threshold: HarmBlockThreshold.BLOCK_MEDIUM_AND_ABOVE }
+      { category: HarmCategory.HARM_CATEGORY_HARASSMENT, threshold: HarmBlockThreshold.BLOCK_NONE },
+      { category: HarmCategory.HARM_CATEGORY_HATE_SPEECH, threshold: HarmBlockThreshold.BLOCK_NONE },
+      { category: HarmCategory.HARM_CATEGORY_SEXUALLY_EXPLICIT, threshold: HarmBlockThreshold.BLOCK_NONE },
+      { category: HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT, threshold: HarmBlockThreshold.BLOCK_NONE }
     ]
   });
 


### PR DESCRIPTION
## Summary
- render markdown in chat UI and review modal
- allow messages to use full width so long text wraps
- lower Gemini safety thresholds
- add initial financial snapshot when chat opens
- include `react-markdown` dependency

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails: cannot find name 'jest')*
- `npm test` *(fails: jest not found)*