### PR TITLE
Fix goal calculations and chat handling

### DIFF
--- a/components/dashboard/ChatInterface.tsx
+++ b/components/dashboard/ChatInterface.tsx
@@ -83,7 +83,7 @@ export default function ChatInterface() {
       });
 
       let aiText = "Sorry, I couldn't get a response. Please try again.";
-      if (response.success && response.data) {
+      if (response.success && response.data && response.data.message.trim()) {
         aiText = response.data.message;
       } else if (response.error) {
         aiText = response.error;

--- a/pages/api/chat.ts
+++ b/pages/api/chat.ts
@@ -129,11 +129,14 @@ Response:
 
     const result = await chat.sendMessage(prompt); // Send the full context as the first message in a new chat
     const aiResponseText = result.response.text();
+    const finalMessage = aiResponseText && aiResponseText.trim()
+      ? aiResponseText
+      : "I'm sorry, I couldn't generate a response.";
 
     return res.status(200).json({
       success: true,
       data: {
-        message: aiResponseText,
+        message: finalMessage,
       },
     });
 

--- a/pages/api/dashboard/overview.ts
+++ b/pages/api/dashboard/overview.ts
@@ -100,7 +100,7 @@ export default createApiHandler<DashboardResponse>(async (
     const yearsUntilRetirement = Math.max(0, retirementAge - age);
 
     // Calculate financial projections
-    const currentSavings = totalAssets;
+    const currentSavings = netWorth;
     const annualContribution = assets
       .filter(asset => asset.annualContribution)
       .reduce((sum, asset) => sum + (asset.annualContribution || 0), 0);

--- a/pages/api/review/[recordType].ts
+++ b/pages/api/review/[recordType].ts
@@ -43,9 +43,11 @@ export default createApiHandler<string>(async (
     const abs = path.join(process.cwd(), 'public', record.statementPath);
     try {
       const data = await fs.promises.readFile(abs);
-      pdfPart = { inlineData: { data: data.toString('base64'), mimeType: 'application/pdf' } };
-    } catch {
-      // ignore missing file
+      pdfPart = {
+        inlineData: { data: data.toString('base64'), mimeType: 'application/pdf' },
+      };
+    } catch (err) {
+      console.warn('Statement file not found:', abs, err);
     }
   }
 

--- a/pages/dashboard/goals/index.tsx
+++ b/pages/dashboard/goals/index.tsx
@@ -298,11 +298,12 @@ const Goals: NextPageWithLayout = () => {
 
   const calculateSuccessPercentage = (goal: Goal) => {
     if (!goal.targetDate) return 0;
-    const years = Math.max(0, (goal.targetDate.getTime() - Date.now()) / (1000 * 60 * 60 * 24 * 365.25));
-    const relevantAssets = goal.name.toLowerCase().includes('retirement')
-      ? assets.filter(isRetirementAsset)
-      : assets.filter(a => !isRetirementAsset(a));
-    const projected = relevantAssets.map(a => ({
+    const years = Math.max(
+      0,
+      (goal.targetDate.getTime() - Date.now()) / (1000 * 60 * 60 * 24 * 365.25),
+    );
+    // Use all assets for projections to keep progress consistent across goals
+    const projected = assets.map(a => ({
       balance: a.balance,
       growthRate: a.growthRate,
       interestRate: a.interestRate,
@@ -383,7 +384,11 @@ const Goals: NextPageWithLayout = () => {
         >
           {goals.length > 0 ? (
             <>
-              {goals.map(goal => {
+              {goals
+                .filter(
+                  (g, idx, arr) => arr.findIndex(o => o.id === g.id) === idx,
+                )
+                .map(goal => {
                 const progress = calculateProgress(goal.currentAmount, goal.targetAmount);
                 const monthsRemaining = goal.targetDate ? calculateMonthsRemaining(goal.targetDate) : null;
                 const monthlySavings = goal.targetDate ? calculateRequiredMonthlySavings(goal) : null;

--- a/utils/tvm.ts
+++ b/utils/tvm.ts
@@ -22,7 +22,15 @@ export function calculateGoalSuccess(
   goalYears: number,
   assets: AssetProjectionInput[],
 ): number {
-  const totalFuture = assets.reduce((sum, asset) => sum + projectAssetValue(asset, goalYears), 0);
+  const startBalance = assets.reduce((sum, asset) => sum + asset.balance, 0);
+  const totalFuture = assets.reduce(
+    (sum, asset) => sum + projectAssetValue(asset, goalYears),
+    0,
+  );
   if (goalAmount === 0) return 100;
+  // If goal date is in the past, compare current balance
+  if (goalYears <= 0) {
+    return Math.min(100, (startBalance / goalAmount) * 100);
+  }
   return Math.min(100, (totalFuture / goalAmount) * 100);
 }


### PR DESCRIPTION
## Summary
- dedupe goals when rendering and include all assets in projections
- handle blank responses gracefully in chat frontend and backend
- log missing statement files
- base dashboard projections on net worth
- update goal success calc to use current balances

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: numerous TS errors due to missing dependencies)*
- `npm test` *(fails: jest not found)*