### PR TITLE
Fix projection graph scaling

### DIFF
--- a/components/dashboard/FinancialProjectionsCard.tsx
+++ b/components/dashboard/FinancialProjectionsCard.tsx
@@ -10,11 +10,58 @@ type FinancialProjectionsCardProps = {
   yearsUntilRetirement: number;
 };
 
-export default function FinancialProjectionsCard({ 
-  projections, 
-  yearsUntilRetirement 
+export default function FinancialProjectionsCard({
+  projections,
+  yearsUntilRetirement
 }: FinancialProjectionsCardProps) {
-  const maxValue = Math.max(...projections.map(p => p.value));
+  if (!projections || projections.length === 0) {
+    return (
+      <div className="card h-full flex items-center justify-center p-4">
+        <p className="text-sm text-gray-500">No projection data available.</p>
+      </div>
+    );
+  }
+
+  const values = projections.map(p => p.value);
+  const dataMin = Math.min(...values);
+  const dataMax = Math.max(...values);
+
+  let displayMin = dataMin;
+  let displayMax = dataMax;
+
+  if (dataMin >= 0 && dataMax >= 0) {
+    displayMin = 0;
+    displayMax = dataMax;
+  } else if (dataMin <= 0 && dataMax <= 0) {
+    displayMax = 0;
+    displayMin = dataMin;
+  }
+
+  if (displayMin === displayMax) {
+    displayMax = displayMin + 1;
+  }
+
+  const displayRange = displayMax - displayMin;
+
+  const getYPercentage = (value: number) => {
+    if (displayRange === 0) return 50;
+    const normalized = (value - displayMin) / displayRange;
+    return (1 - normalized) * 100;
+  };
+
+  const getXPercentage = (index: number, total: number) => {
+    if (total <= 1) return 0;
+    return (index / (total - 1)) * 100;
+  };
+
+  const firstYear = projections[0].year;
+  const lastYear = projections[projections.length - 1].year;
+  const totalYears = lastYear - firstYear;
+  let retirementLineX = 0;
+  if (totalYears > 0) {
+    retirementLineX = ((yearsUntilRetirement - firstYear) / totalYears) * 100;
+    retirementLineX = Math.max(0, Math.min(100, retirementLineX));
+  }
   const formatCurrency = (amount: number) => {
     return new Intl.NumberFormat('en-US', {
       style: 'currency',
@@ -24,6 +71,14 @@ export default function FinancialProjectionsCard({
     }).format(amount);
   };
 
+  const yLabels = [
+    displayMax,
+    displayMax - displayRange * 0.25,
+    displayMax - displayRange * 0.5,
+    displayMax - displayRange * 0.75,
+    displayMin,
+  ];
+
   return (
     <div className="card h-full">
       <h3 className="mb-4 text-lg font-medium text-gray-700">Financial Projections</h3>
@@ -32,11 +87,9 @@ export default function FinancialProjectionsCard({
         <div className="relative h-full w-full">
           {/* Y-axis labels */}
           <div className="absolute left-0 top-0 flex h-full flex-col justify-between pb-6 pr-2 text-xs text-gray-500">
-            <span>{formatCurrency(maxValue)}</span>
-            <span>{formatCurrency(maxValue * 0.75)}</span>
-            <span>{formatCurrency(maxValue * 0.5)}</span>
-            <span>{formatCurrency(maxValue * 0.25)}</span>
-            <span>{formatCurrency(0)}</span>
+            {yLabels.map((label, idx) => (
+              <span key={idx}>{formatCurrency(label)}</span>
+            ))}
           </div>
           
           {/* Graph area */}
@@ -55,9 +108,9 @@ export default function FinancialProjectionsCard({
               <div className="absolute bottom-0 left-0 right-0 border-t border-gray-300" />
               
               {/* Retirement line */}
-              <div 
+              <div
                 className="absolute bottom-0 top-0 border-l border-dashed border-error"
-                style={{ left: `${(yearsUntilRetirement / projections.length) * 100}%` }}
+                style={{ left: `${retirementLineX}%` }}
               >
                 <div className="absolute -left-6 top-0 rounded bg-error px-1 text-xs text-white">
                   Retirement
@@ -79,12 +132,13 @@ export default function FinancialProjectionsCard({
                   animate={{ pathLength: 1, opacity: 1 }}
                   transition={{ duration: 1.5, ease: "easeInOut" }}
                   d={`
-                    M 0 ${(1 - (projections[0]?.value || 0) / maxValue) * 100}
-                    ${projections.map((point, i) => 
-                      `L ${(i / (projections.length - 1)) * 100} ${(1 - point.value / maxValue) * 100}`
-                    ).join(' ')}
-                    L 100 100
-                    L 0 100
+                    ${projections
+                      .map((point, i) =>
+                        `${i === 0 ? 'M' : 'L'} ${getXPercentage(i, projections.length)} ${getYPercentage(point.value)}`
+                      )
+                      .join(' ')}
+                    L ${getXPercentage(projections.length - 1, projections.length)} 100
+                    L ${getXPercentage(0, projections.length)} 100
                     Z
                   `}
                   fill="url(#projectionGradient)"
@@ -98,10 +152,11 @@ export default function FinancialProjectionsCard({
                   animate={{ pathLength: 1, opacity: 1 }}
                   transition={{ duration: 1.5, ease: "easeInOut" }}
                   d={`
-                    M 0 ${(1 - (projections[0]?.value || 0) / maxValue) * 100}
-                    ${projections.map((point, i) => 
-                      `L ${(i / (projections.length - 1)) * 100} ${(1 - point.value / maxValue) * 100}`
-                    ).join(' ')}
+                    ${projections
+                      .map((point, i) =>
+                        `${i === 0 ? 'M' : 'L'} ${getXPercentage(i, projections.length)} ${getYPercentage(point.value)}`
+                      )
+                      .join(' ')}
                   `}
                   fill="none"
                   stroke="#2196F3"


### PR DESCRIPTION
## Summary
- fix y-axis scaling for projections graph
- handle empty/negative data and single points
- update retirement line positioning

## Testing
- `npm test` *(fails: jest not found)*
- `npm run typecheck` *(fails: cannot find name 'jest')*