### PR TITLE
Refactor main UI to Statement Analyzer

### DIFF
--- a/__tests__/statement-upload.test.ts
+++ b/__tests__/statement-upload.test.ts
@@ -11,9 +11,7 @@ jest.mock('fs', () => ({
 jest.mock('@google/generative-ai', () => {
   const mockGenerate = jest.fn().mockResolvedValue({
     response: {
-      text: () => '```json
-{"recordType":"asset","asset":{"type":"Cash","subtype":"Checking","name":"Bank","balance":100}}
-```',
+      text: () => '```json\n[{"recordType":"asset","asset":{"type":"Cash","subtype":"Checking","name":"Bank","balance":100}}]\n```',
     },
   });
   const mockModel = { generateContent: mockGenerate };
@@ -71,7 +69,9 @@ describe('statement-upload', () => {
     expect(res.status).toHaveBeenCalledWith(200);
     expect(res.json).toHaveBeenCalledWith({
       success: true,
-      data: { recordType: 'asset', asset: { type: 'Cash', subtype: 'Checking', name: 'Bank', balance: 100 } },
+      data: [
+        { recordType: 'asset', asset: { type: 'Cash', subtype: 'Checking', name: 'Bank', balance: 100 } }
+      ],
     });
   });
 });

--- a/components/dashboard/StatementUploadModal.tsx
+++ b/components/dashboard/StatementUploadModal.tsx
@@ -33,7 +33,7 @@ export interface ParsedStatement {
 
 interface Props {
   onClose: () => void;
-  onParsed: (data: ParsedStatement) => void;
+  onParsed: (data: ParsedStatement[]) => void;
 }
 
 const StatementUploadModal = ({ onClose, onParsed }: Props) => {
@@ -70,7 +70,7 @@ const StatementUploadModal = ({ onClose, onParsed }: Props) => {
     setIsUploading(true);
     try {
       const base64 = await fileToBase64(file);
-      const response = await fetchApi<ParsedStatement>('/api/statement-upload', {
+      const response = await fetchApi<ParsedStatement[]>('/api/statement-upload', {
         method: 'POST',
         body: JSON.stringify({ filename: file.name, file: base64 }),
       });

--- a/components/layout/Navbar.tsx
+++ b/components/layout/Navbar.tsx
@@ -28,50 +28,20 @@ export default function Navbar() {
         <div className="flex h-16 justify-between">
           <div className="flex">
             <div className="flex flex-shrink-0 items-center">
-              <Link href="/dashboard" className="text-xl font-bold text-primary">
+              <Link href="/analyzer" className="text-xl font-bold text-primary">
                 Pocket FA
               </Link>
             </div>
             <div className="hidden sm:ml-6 sm:flex sm:space-x-8">
               <Link
-                href="/dashboard"
+                href="/analyzer"
                 className={`inline-flex items-center border-b-2 px-1 pt-1 text-sm font-medium ${
-                  router.pathname === '/dashboard'
+                  router.pathname === '/analyzer'
                     ? 'border-primary text-gray-900'
                     : 'border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700'
                 }`}
               >
-                Dashboard
-              </Link>
-              <Link
-                href="/dashboard/assets"
-                className={`inline-flex items-center border-b-2 px-1 pt-1 text-sm font-medium ${
-                  router.pathname.startsWith('/dashboard/assets')
-                    ? 'border-primary text-gray-900'
-                    : 'border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700'
-                }`}
-              >
-                Assets
-              </Link>
-              <Link
-                href="/dashboard/debts"
-                className={`inline-flex items-center border-b-2 px-1 pt-1 text-sm font-medium ${
-                  router.pathname.startsWith('/dashboard/debts')
-                    ? 'border-primary text-gray-900'
-                    : 'border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700'
-                }`}
-              >
-                Debts
-              </Link>
-              <Link
-                href="/dashboard/goals"
-                className={`inline-flex items-center border-b-2 px-1 pt-1 text-sm font-medium ${
-                  router.pathname.startsWith('/dashboard/goals')
-                    ? 'border-primary text-gray-900'
-                    : 'border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700'
-                }`}
-              >
-                Goals
+                Statement Analyzer
               </Link>
             </div>
           </div>
@@ -163,44 +133,14 @@ export default function Navbar() {
       <div className="sm:hidden" id="mobile-menu">
         <div className="space-y-1 pt-2 pb-3">
           <Link
-            href="/dashboard"
+            href="/analyzer"
             className={`block border-l-4 py-2 pl-3 pr-4 text-base font-medium ${
-              router.pathname === '/dashboard'
+              router.pathname === '/analyzer'
                 ? 'border-primary bg-primary-50 text-primary'
                 : 'border-transparent text-gray-600 hover:border-gray-300 hover:bg-gray-50 hover:text-gray-800'
             }`}
           >
-            Dashboard
-          </Link>
-          <Link
-            href="/dashboard/assets"
-            className={`block border-l-4 py-2 pl-3 pr-4 text-base font-medium ${
-              router.pathname.startsWith('/dashboard/assets')
-                ? 'border-primary bg-primary-50 text-primary'
-                : 'border-transparent text-gray-600 hover:border-gray-300 hover:bg-gray-50 hover:text-gray-800'
-            }`}
-          >
-            Assets
-          </Link>
-          <Link
-            href="/dashboard/debts"
-            className={`block border-l-4 py-2 pl-3 pr-4 text-base font-medium ${
-              router.pathname.startsWith('/dashboard/debts')
-                ? 'border-primary bg-primary-50 text-primary'
-                : 'border-transparent text-gray-600 hover:border-gray-300 hover:bg-gray-50 hover:text-gray-800'
-            }`}
-          >
-            Debts
-          </Link>
-          <Link
-            href="/dashboard/goals"
-            className={`block border-l-4 py-2 pl-3 pr-4 text-base font-medium ${
-              router.pathname.startsWith('/dashboard/goals')
-                ? 'border-primary bg-primary-50 text-primary'
-                : 'border-transparent text-gray-600 hover:border-gray-300 hover:bg-gray-50 hover:text-gray-800'
-            }`}
-          >
-            Goals
+            Statement Analyzer
           </Link>
         </div>
         <div className="border-t border-gray-200 pt-4 pb-3">

--- a/hooks/useAuth.tsx
+++ b/hooks/useAuth.tsx
@@ -96,7 +96,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         }
       }
       
-      router.push('/dashboard');
+      router.push('/analyzer');
     } catch (error) {
       console.error('Login error:', error);
       throw error;

--- a/pages/analyzer.tsx
+++ b/pages/analyzer.tsx
@@ -1,0 +1,167 @@
+import { useState, useEffect } from 'react';
+import DashboardLayout from '../components/layout/DashboardLayout';
+import Modal from '../components/layout/Modal';
+import AssetForm from '../components/dashboard/AssetForm';
+import DebtForm from '../components/dashboard/DebtForm';
+import StatementUploadModal from '../components/dashboard/StatementUploadModal';
+import ReviewButton from '../components/dashboard/ReviewButton';
+import { NextPageWithLayout } from './_app';
+import { fetchApi } from '../lib/api-utils';
+
+type Asset = {
+  id?: string;
+  type: string;
+  subtype?: string | null;
+  name: string;
+  balance: number;
+  interestRate?: number | null;
+  annualContribution?: number | null;
+  growthRate?: number | null;
+  assetClass?: string | null;
+};
+
+type Debt = {
+  id?: string;
+  type: string;
+  lender: string;
+  balance: number;
+  interestRate: number;
+  monthlyPayment: number;
+  termLength?: number | null;
+};
+
+type RecordItem = { recordType: 'asset' | 'debt'; data: Asset | Debt };
+
+type ParsedRecord = {
+  recordType: 'asset' | 'debt';
+  asset?: Asset;
+  debt?: Debt;
+};
+
+const Analyzer: NextPageWithLayout = () => {
+  const [records, setRecords] = useState<RecordItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [uploadOpen, setUploadOpen] = useState(false);
+  const [formOpen, setFormOpen] = useState(false);
+  const [formType, setFormType] = useState<'asset' | 'debt' | null>(null);
+  const [editing, setEditing] = useState<any>(null);
+  const [queue, setQueue] = useState<ParsedRecord[]>([]);
+
+  useEffect(() => {
+    fetchRecords();
+  }, []);
+
+  const fetchRecords = async () => {
+    try {
+      setLoading(true);
+      const [assetRes, debtRes] = await Promise.all([
+        fetchApi<Asset[]>('/api/dashboard/assets'),
+        fetchApi<Debt[]>('/api/dashboard/debts'),
+      ]);
+      const items: RecordItem[] = [];
+      if (assetRes.success && assetRes.data) {
+        assetRes.data.forEach((a) => items.push({ recordType: 'asset', data: a }));
+      }
+      if (debtRes.success && debtRes.data) {
+        debtRes.data.forEach((d) => items.push({ recordType: 'debt', data: d }));
+      }
+      setRecords(items);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load records');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const openNextFromQueue = () => {
+    const next = queue[0];
+    if (!next) return;
+    setQueue(queue.slice(1));
+    if (next.recordType === 'asset' && next.asset) {
+      setFormType('asset');
+      setEditing(next.asset);
+      setFormOpen(true);
+    } else if (next.recordType === 'debt' && next.debt) {
+      setFormType('debt');
+      setEditing(next.debt);
+      setFormOpen(true);
+    }
+  };
+
+  const handleParsed = (data: ParsedRecord[]) => {
+    if (Array.isArray(data)) {
+      setQueue(data);
+      openNextFromQueue();
+    }
+  };
+
+  const handleAddRecord = async (payload: any) => {
+    if (!formType) return;
+    const url = formType === 'asset' ? '/api/dashboard/assets' : '/api/dashboard/debts';
+    const res = await fetchApi(url, { method: 'POST', body: JSON.stringify(payload) });
+    if (res.success) {
+      setFormOpen(false);
+      setEditing(null);
+      await fetchRecords();
+      openNextFromQueue();
+    } else {
+      setError(res.error || 'Failed to save record');
+    }
+  };
+
+  const formatCurrency = (val: number) => new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(val);
+
+  return (
+    <>
+      <div className="mb-6 flex items-center justify-between">
+        <h1 className="text-3xl font-bold text-gray-900">Statement Analyzer</h1>
+        <button className="btn btn-primary" onClick={() => setUploadOpen(true)}>
+          Upload Statement
+        </button>
+      </div>
+      {error && <p className="mb-4 text-red-500">{error}</p>}
+      {loading ? (
+        <p>Loading...</p>
+      ) : (
+        <div className="space-y-4">
+          {records.map((item) => (
+            <div key={(item.data as any).id} className="rounded-md bg-white p-4 shadow">
+              <div className="flex justify-between">
+                <div>
+                  <p className="font-medium text-gray-900">
+                    {item.recordType === 'asset' ? (item.data as Asset).name : (item.data as Debt).lender}
+                  </p>
+                  <p className="text-sm text-gray-500">
+                    {item.recordType} - {(item.data as any).type}
+                  </p>
+                </div>
+                <div className="text-right space-x-2">
+                  <span className="text-sm text-gray-700">{formatCurrency((item.data as any).balance)}</span>
+                  <ReviewButton recordType={item.recordType} record={item.data} />
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+      <Modal isOpen={uploadOpen} onClose={() => setUploadOpen(false)} title="Upload Statement">
+        <StatementUploadModal onClose={() => setUploadOpen(false)} onParsed={handleParsed} />
+      </Modal>
+      <Modal isOpen={formOpen} onClose={() => setFormOpen(false)} title="Confirm Data">
+        {formType === 'asset' && (
+          <AssetForm onSubmit={handleAddRecord} onCancel={() => setFormOpen(false)} initialValues={editing} isSubmitting={false} />
+        )}
+        {formType === 'debt' && (
+          <DebtForm onSubmit={handleAddRecord} onCancel={() => setFormOpen(false)} initialValues={editing} isSubmitting={false} />
+        )}
+      </Modal>
+    </>
+  );
+};
+
+Analyzer.getLayout = (page: React.ReactElement) => (
+  <DashboardLayout title="Statement Analyzer | Pocket Financial Advisor">{page}</DashboardLayout>
+);
+
+export default Analyzer;

--- a/pages/dashboard/assets/index.tsx
+++ b/pages/dashboard/assets/index.tsx
@@ -166,15 +166,17 @@ const Assets: NextPageWithLayout = () => {
     }).format(amount);
   };
 
-  const handleParsedStatement = (data: ParsedStatement) => {
-    if (data.recordType === 'asset' && data.asset) {
+  const handleParsedStatement = (data: ParsedStatement[]) => {
+    const first = data[0];
+    if (!first) return;
+    if (first.recordType === 'asset' && first.asset) {
       setModalType('asset');
-      setParsedAsset(data.asset);
+      setParsedAsset(first.asset);
       setEditingAsset(null);
       setIsModalOpen(true);
-    } else if (data.recordType === 'debt' && data.debt) {
+    } else if (first.recordType === 'debt' && first.debt) {
       setModalType('debt');
-      setParsedDebt(data.debt);
+      setParsedDebt(first.debt);
       setEditingDebt(null);
       setIsModalOpen(true);
     }

--- a/pages/dashboard/debts/index.tsx
+++ b/pages/dashboard/debts/index.tsx
@@ -176,15 +176,17 @@ const Debts: NextPageWithLayout = () => {
     return (totalMonthlyPayment / monthlyIncome) * 100;
   };
 
-  const handleParsedStatement = (data: ParsedStatement) => {
-    if (data.recordType === 'debt' && data.debt) {
+  const handleParsedStatement = (data: ParsedStatement[]) => {
+    const first = data[0];
+    if (!first) return;
+    if (first.recordType === 'debt' && first.debt) {
       setModalType('debt');
-      setParsedDebt(data.debt);
+      setParsedDebt(first.debt);
       setEditingDebt(null);
       setIsModalOpen(true);
-    } else if (data.recordType === 'asset' && data.asset) {
+    } else if (first.recordType === 'asset' && first.asset) {
       setModalType('asset');
-      setParsedAsset(data.asset);
+      setParsedAsset(first.asset);
       setEditingAsset(null);
       setIsModalOpen(true);
     }


### PR DESCRIPTION
## Summary
- add new Analyzer page as primary dashboard
- redirect login flow to analyzer
- simplify navigation to just Statement Analyzer
- update statement upload API to return an array of accounts
- adjust statement upload modal and dashboard pages for new API
- update tests for new multi-account response

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: missing dependencies)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b5979c16c8324bac0bd9ece8da91d