### PR TITLE
Enable iterative statement review

### DIFF
--- a/components/dashboard/ReviewModal.tsx
+++ b/components/dashboard/ReviewModal.tsx
@@ -38,7 +38,7 @@ export default function ReviewModal({ isOpen, onClose, recordType, record }: Pro
     setLoading(true);
     const res = await fetchApi<string>(`/api/review/${recordType}`, {
       method: 'POST',
-      body: JSON.stringify({ record })
+      body: JSON.stringify({ record, history: [] })
     });
     let newAiText = 'Error processing your request.';
     if (res.success) {
@@ -57,14 +57,15 @@ export default function ReviewModal({ isOpen, onClose, recordType, record }: Pro
   const sendMessage = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!input.trim()) return;
-    const userMsg: Message = { id: Date.now().toString(), sender: 'user', text: input };
-    setMessages(prev => [...prev, userMsg]);
     const current = input;
+    const historyForServer = messages.map(m => ({ sender: m.sender, text: m.text }));
+    const userMsg: Message = { id: Date.now().toString(), sender: 'user', text: current };
+    setMessages(prev => [...prev, userMsg]);
     setInput('');
     setLoading(true);
     const res = await fetchApi<string>(`/api/review/${recordType}`, {
       method: 'POST',
-      body: JSON.stringify({ record, message: current })
+      body: JSON.stringify({ record, message: current, history: historyForServer })
     });
     let newAiText = 'Error processing your request.';
     if (res.success) {


### PR DESCRIPTION
## Summary
- allow sending history to the review API
- keep PDF and record context in a system prompt and use `startChat`
- post conversation history from `ReviewModal`

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails: missing type declarations)*
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b663ea79083248d115cfebc46f4a0