### PR TITLE
Enable review API to accept base64 statements

### DIFF
--- a/__tests__/review.test.ts
+++ b/__tests__/review.test.ts
@@ -1,4 +1,23 @@
 import handler from '../pages/api/review/[recordType]';
+import fs from 'fs';
+
+jest.mock('fs', () => ({
+  promises: {
+    readFile: jest.fn().mockResolvedValue(Buffer.from('dummy')),
+  },
+}));
+
+const mockSend = jest.fn().mockResolvedValue({ response: { text: () => 'ok' } });
+const mockChat = { sendMessage: mockSend };
+const mockStart = jest.fn().mockReturnValue(mockChat);
+const mockModel = { startChat: mockStart };
+const mockGetModel = jest.fn().mockReturnValue(mockModel);
+
+jest.mock('@google/generative-ai', () => ({
+  GoogleGenerativeAI: jest.fn().mockImplementation(() => ({ getGenerativeModel: mockGetModel })),
+  HarmCategory: { HARM_CATEGORY_HARASSMENT: 0, HARM_CATEGORY_HATE_SPEECH: 1, HARM_CATEGORY_SEXUALLY_EXPLICIT: 2, HARM_CATEGORY_DANGEROUS_CONTENT: 3 },
+  HarmBlockThreshold: { BLOCK_NONE: 0 },
+}));
 
 const createMocks = () => {
   const req: any = { method: 'GET', query: { recordType: 'asset' }, body: {}, headers: {} };
@@ -11,5 +30,18 @@ describe('review api', () => {
     const { req, res } = createMocks();
     await (handler as any)(req, res);
     expect(res.status).toHaveBeenCalledWith(405);
+  });
+
+  it('uses pdfBase64 when provided', async () => {
+    process.env.GEMINI_API_KEY = 'test';
+    process.env.NODE_ENV = 'development';
+    const { req, res } = createMocks();
+    req.method = 'POST';
+    req.body = { record: { name: 'Test' }, pdfBase64: 'Zm9v', history: [] };
+    await (handler as any)(req, res);
+    expect(fs.promises.readFile).not.toHaveBeenCalled();
+    const call = mockStart.mock.calls[0][0];
+    expect(call.history[0].parts[0]).toEqual({ inlineData: { data: 'Zm9v', mimeType: 'application/pdf' } });
+    expect(res.status).toHaveBeenCalledWith(200);
   });
 });

--- a/components/dashboard/ReviewModal.tsx
+++ b/components/dashboard/ReviewModal.tsx
@@ -38,7 +38,7 @@ export default function ReviewModal({ isOpen, onClose, recordType, record }: Pro
     setLoading(true);
     const res = await fetchApi<string>(`/api/review/${recordType}`, {
       method: 'POST',
-      body: JSON.stringify({ record, history: [] })
+      body: JSON.stringify({ record, history: [], pdfBase64: (record as any).pdfBase64 })
     });
     let newAiText = 'Error processing your request.';
     if (res.success) {
@@ -65,7 +65,7 @@ export default function ReviewModal({ isOpen, onClose, recordType, record }: Pro
     setLoading(true);
     const res = await fetchApi<string>(`/api/review/${recordType}`, {
       method: 'POST',
-      body: JSON.stringify({ record, message: current, history: historyForServer })
+      body: JSON.stringify({ record, message: current, history: historyForServer, pdfBase64: (record as any).pdfBase64 })
     });
     let newAiText = 'Error processing your request.';
     if (res.success) {

--- a/components/dashboard/StatementUploadModal.tsx
+++ b/components/dashboard/StatementUploadModal.tsx
@@ -12,6 +12,7 @@ export interface AssetData {
   assetClass?: string;
   statementPath?: string;
   statementName?: string;
+  pdfBase64?: string;
 }
 
 export interface DebtData {
@@ -23,6 +24,7 @@ export interface DebtData {
   termLength?: number;
   statementPath?: string;
   statementName?: string;
+  pdfBase64?: string;
 }
 
 export interface ParsedStatement {
@@ -75,7 +77,16 @@ const StatementUploadModal = ({ onClose, onParsed }: Props) => {
         body: JSON.stringify({ filename: file.name, file: base64 }),
       });
       if (response.success && response.data) {
-        onParsed(response.data);
+        const augmented = response.data.map(r => {
+          if (r.recordType === 'asset' && r.asset) {
+            return { ...r, asset: { ...r.asset, pdfBase64: base64 } };
+          }
+          if (r.recordType === 'debt' && r.debt) {
+            return { ...r, debt: { ...r.debt, pdfBase64: base64 } };
+          }
+          return r;
+        });
+        onParsed(augmented);
         onClose();
       } else {
         setError(response.error || 'Failed to process statement');

--- a/pages/api/review/[recordType].ts
+++ b/pages/api/review/[recordType].ts
@@ -8,6 +8,7 @@ interface ReviewRequest {
   record: any;
   message?: string;
   history?: { sender: 'user' | 'ai'; text: string }[];
+  pdfBase64?: string;
 }
 
 const MODEL_NAME = 'gemini-2.5-flash-preview-04-17';
@@ -32,7 +33,7 @@ export default createApiHandler<string>(async (
     return res.status(400).json({ success: false, error: 'Invalid record type' });
   }
 
-  const { record, message, history = [] } = req.body as ReviewRequest;
+  const { record, message, history = [], pdfBase64 } = req.body as ReviewRequest;
   if (!record) {
     return res.status(400).json({ success: false, error: 'Record data is required' });
   }
@@ -43,7 +44,9 @@ export default createApiHandler<string>(async (
   const model = genAI.getGenerativeModel({ model: MODEL_NAME });
 
   let pdfPart;
-  if (record.statementPath) {
+  if (pdfBase64) {
+    pdfPart = { inlineData: { data: pdfBase64, mimeType: 'application/pdf' } };
+  } else if (record.statementPath) {
     console.log('Statement path found:', record.statementPath);
     const abs = path.join(process.cwd(), 'public', record.statementPath);
     console.log('Reading statement from:', abs);


### PR DESCRIPTION
## Summary
- support `pdfBase64` in review API
- pass uploaded PDF data to the review modal
- include pdf data from statement upload in parsed records
- test new API behavior when a base64 string is provided

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails: cannot find modules)*
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b7f831be883249a24f2bcd17ab7cd