### PR TITLE
Use global context cache

### DIFF
--- a/lib/context-cache.ts
+++ b/lib/context-cache.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'crypto';
 
-const cache = new Map<string, any>();
+const globalForCache = globalThis as { contextCache?: Map<string, any> };
+const cache = (globalForCache.contextCache ||= new Map<string, any>());
 
 export function storeContext(data: any): string {
   const id = randomUUID();


### PR DESCRIPTION
## Summary
- share context cache across API routes by attaching map to `globalThis`

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: missing type definitions)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cb48941d083248bc5f42496761e7c