### PR TITLE
Optimize review chat payloads

### DIFF
--- a/components/dashboard/ReviewButton.tsx
+++ b/components/dashboard/ReviewButton.tsx
@@ -1,12 +1,31 @@
 import { useState } from 'react';
 import ReviewModal from './ReviewModal';
+import { fetchApi } from '../../lib/api-utils';
 
 export default function ReviewButton({ recordType, record }: { recordType: 'asset' | 'debt'; record: any; }) {
   const [open, setOpen] = useState(false);
+  const [contextId, setContextId] = useState<string | null>(null);
+
+  const handleOpen = async () => {
+    const res = await fetchApi<string>('/api/chat/create-context', {
+      method: 'POST',
+      body: JSON.stringify({ data: record })
+    });
+
+    if (res.success && res.data) {
+      setContextId(res.data);
+      setOpen(true);
+    } else {
+      console.error(res.error || 'Failed to create context');
+    }
+  };
+
   return (
     <>
-      <button className="text-green-600 hover:text-green-900" onClick={() => setOpen(true)}>Review</button>
-      <ReviewModal isOpen={open} onClose={() => setOpen(false)} recordType={recordType} record={record} />
+      <button className="text-green-600 hover:text-green-900" onClick={handleOpen}>Review</button>
+      {contextId && (
+        <ReviewModal isOpen={open} onClose={() => setOpen(false)} recordType={recordType} contextId={contextId} />
+      )}
     </>
   );
 }

--- a/components/dashboard/ReviewModal.tsx
+++ b/components/dashboard/ReviewModal.tsx
@@ -7,7 +7,7 @@ interface Props {
   isOpen: boolean;
   onClose: () => void;
   recordType: 'asset' | 'debt';
-  record: any;
+  contextId: string;
 }
 
 interface Message {
@@ -16,7 +16,7 @@ interface Message {
   text: string;
 }
 
-export default function ReviewModal({ isOpen, onClose, recordType, record }: Props) {
+export default function ReviewModal({ isOpen, onClose, recordType, contextId }: Props) {
   const [messages, setMessages] = useState<Message[]>([]);
   const [input, setInput] = useState('');
   const [loading, setLoading] = useState(false);
@@ -28,7 +28,7 @@ export default function ReviewModal({ isOpen, onClose, recordType, record }: Pro
       setInput('');
       fetchInitial();
     }
-  }, [isOpen]);
+  }, [isOpen, contextId]);
 
   useEffect(() => {
     if (endRef.current) endRef.current.scrollIntoView({ behavior: 'smooth' });
@@ -38,7 +38,7 @@ export default function ReviewModal({ isOpen, onClose, recordType, record }: Pro
     setLoading(true);
     const res = await fetchApi<string>(`/api/review/${recordType}`, {
       method: 'POST',
-      body: JSON.stringify({ record, history: [], pdfBase64: (record as any).pdfBase64 })
+      body: JSON.stringify({ contextId })
     });
     let newAiText = 'Error processing your request.';
     if (res.success) {
@@ -58,14 +58,13 @@ export default function ReviewModal({ isOpen, onClose, recordType, record }: Pro
     e.preventDefault();
     if (!input.trim()) return;
     const current = input;
-    const historyForServer = messages.map(m => ({ sender: m.sender, text: m.text }));
     const userMsg: Message = { id: Date.now().toString(), sender: 'user', text: current };
     setMessages(prev => [...prev, userMsg]);
     setInput('');
     setLoading(true);
     const res = await fetchApi<string>(`/api/review/${recordType}`, {
       method: 'POST',
-      body: JSON.stringify({ record, message: current, history: historyForServer, pdfBase64: (record as any).pdfBase64 })
+      body: JSON.stringify({ contextId, message: current })
     });
     let newAiText = 'Error processing your request.';
     if (res.success) {

--- a/pages/analyzer.tsx
+++ b/pages/analyzer.tsx
@@ -143,8 +143,7 @@ const Analyzer: NextPageWithLayout = () => {
         method: 'POST',
         body: JSON.stringify({
           contextId,
-          message,
-          history: history.map(m => ({ sender: m.sender, text: m.text }))
+          message
         })
       });
 


### PR DESCRIPTION
## Summary
- streamline `/api/review` calls from `analyzer.tsx`
- create review context in `ReviewButton`
- refactor `ReviewModal` to only send `contextId` and new messages

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails: missing type definitions)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684db01f968c8324adcb25fc5ae843da