### PR TITLE
Implement streaming chat with cleanup

### DIFF
--- a/pages/api/chat/end-session.ts
+++ b/pages/api/chat/end-session.ts
@@ -1,0 +1,25 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { createApiHandler, ApiResponse, authenticate } from '../../../lib/api-utils';
+import { clearContext } from '../../../lib/context-cache';
+import { clearChatSession } from '../../../lib/chat-session-cache';
+
+export default createApiHandler<void>(async (
+  req: NextApiRequest,
+  res: NextApiResponse<ApiResponse<void>>
+) => {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ success: false, error: 'Method not allowed' });
+  }
+
+  await authenticate(req);
+
+  const { contextId } = req.body as { contextId?: string };
+  if (!contextId) {
+    return res.status(400).json({ success: false, error: 'contextId is required' });
+  }
+
+  clearContext(contextId);
+  clearChatSession(contextId);
+
+  return res.status(200).json({ success: true });
+});


### PR DESCRIPTION
## Summary
- add session cleanup endpoint
- stream AI responses in the review API
- update ReviewModal to consume stream and cleanup session
- adjust review tests for streaming

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails: cannot find modules)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dc05a59d083248f793afb1648420b