### PR TITLE
Refactor Gemini integration

### DIFF
--- a/components/dashboard/ReviewModal.tsx
+++ b/components/dashboard/ReviewModal.tsx
@@ -47,7 +47,6 @@ export default function ReviewModal({ isOpen, onClose, recordType, contextId }: 
     if (isOpen) {
       setMessages([]);
       setInput('');
-      fetchInitial();
     }
   }, [isOpen, contextId]);
 
@@ -55,27 +54,6 @@ export default function ReviewModal({ isOpen, onClose, recordType, contextId }: 
     if (endRef.current) endRef.current.scrollIntoView({ behavior: 'smooth' });
   }, [messages]);
 
-  const fetchInitial = async () => {
-    setLoading(true);
-    const res = await fetch(`/api/review/${recordType}`, {
-      method: 'POST',
-      headers: buildAuthHeaders(),
-      body: JSON.stringify({ contextId }),
-    });
-    const data = await res.json();
-    let newAiText = 'Error processing your request.';
-    if (data.success) {
-      if (data.data && data.data.trim() !== '') {
-        newAiText = data.data;
-      } else {
-        newAiText = "[The AI didn't provide a specific observation for that.]";
-      }
-    } else if (data.error) {
-      newAiText = data.error;
-    }
-    setMessages([{ id: Date.now().toString(), sender: 'ai', text: newAiText }]);
-    setLoading(false);
-  };
 
   const sendMessage = async (e: React.FormEvent) => {
     e.preventDefault();

--- a/lib/gemini-service.ts
+++ b/lib/gemini-service.ts
@@ -1,0 +1,42 @@
+import { GoogleGenerativeAI, HarmCategory, HarmBlockThreshold, type ChatSession } from '@google/generative-ai';
+
+const MODEL_NAME = 'gemini-2.5-flash-preview-05-20';
+const API_KEY = process.env.GEMINI_API_KEY;
+
+const generationConfig = {
+  temperature: 0.4,
+  maxOutputTokens: 8192,
+};
+
+const safetySettings = [
+  { category: HarmCategory.HARM_CATEGORY_HARASSMENT, threshold: HarmBlockThreshold.BLOCK_NONE },
+  { category: HarmCategory.HARM_CATEGORY_HATE_SPEECH, threshold: HarmBlockThreshold.BLOCK_NONE },
+  { category: HarmCategory.HARM_CATEGORY_SEXUALLY_EXPLICIT, threshold: HarmBlockThreshold.BLOCK_NONE },
+  { category: HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT, threshold: HarmBlockThreshold.BLOCK_NONE },
+];
+
+function getModel() {
+  if (!API_KEY) {
+    throw new Error('GEMINI_API_KEY is not configured');
+  }
+  const globalForModel = globalThis as { geminiModel?: ReturnType<GoogleGenerativeAI['getGenerativeModel']> };
+  if (!globalForModel.geminiModel) {
+    const genAI = new GoogleGenerativeAI(API_KEY);
+    globalForModel.geminiModel = genAI.getGenerativeModel({ model: MODEL_NAME });
+  }
+  return globalForModel.geminiModel!;
+}
+
+export function startChat(history: { role: string; parts: { text: string }[] }[] = []): ChatSession {
+  const model = getModel();
+  return model.startChat({ generationConfig, safetySettings, history });
+}
+
+export async function sendMessage(session: ChatSession, message: string): Promise<string> {
+  const result = await session.sendMessage(message);
+  return result.response.text().trim();
+}
+
+export async function sendMessageStream(session: ChatSession, message: string) {
+  return session.sendMessageStream(message);
+}

--- a/pages/api/review/[recordType].ts
+++ b/pages/api/review/[recordType].ts
@@ -1,11 +1,9 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { createApiHandler, ApiResponse, authenticate } from '../../../lib/api-utils';
-import { GoogleGenerativeAI, HarmCategory, HarmBlockThreshold } from '@google/generative-ai';
+import { startChat, sendMessageStream } from '../../../lib/gemini-service';
 import { getContext } from '../../../lib/context-cache';
 import { storeChatSession, getChatSession } from '../../../lib/chat-session-cache';
 
-const MODEL_NAME = 'gemini-2.5-flash-preview-05-20';
-const API_KEY = process.env.GEMINI_API_KEY;
 
 export default createApiHandler<void>(async (
   req: NextApiRequest,
@@ -15,16 +13,11 @@ export default createApiHandler<void>(async (
     return res.status(405).json({ success: false, error: 'Method not allowed' });
   }
 
-  if (!API_KEY) {
-    return res.status(500).json({ success: false, error: 'AI service not configured' });
-  }
-
   await authenticate(req);
 
-  const { contextId, message, history = [] } = req.body as {
+  const { contextId, message } = req.body as {
     contextId?: string;
     message?: string;
-    history?: { sender: 'user' | 'ai'; text: string }[];
   };
   console.log('🕵️‍♂️ Review API called. Request body:', JSON.stringify(req.body));
 
@@ -37,55 +30,16 @@ export default createApiHandler<void>(async (
     return res.status(400).json({ success: false, error: 'Invalid contextId' });
   }
 
-  const genAI = new GoogleGenerativeAI(API_KEY);
-  const model = genAI.getGenerativeModel({ model: MODEL_NAME });
-
-  const generationConfig = { temperature: 0.4, maxOutputTokens: 8192 };
-  const safetySettings = [
-    { category: HarmCategory.HARM_CATEGORY_HARASSMENT, threshold: HarmBlockThreshold.BLOCK_NONE },
-    { category: HarmCategory.HARM_CATEGORY_HATE_SPEECH, threshold: HarmBlockThreshold.BLOCK_NONE },
-    { category: HarmCategory.HARM_CATEGORY_SEXUALLY_EXPLICIT, threshold: HarmBlockThreshold.BLOCK_NONE },
-    { category: HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT, threshold: HarmBlockThreshold.BLOCK_NONE },
-  ];
-
-  // Prime call: no initial message => immediately inject full context
-  const isPrimeCall = message === undefined && history.length === 0;
-  console.log(`→ isPrimeCall=${isPrimeCall}, history.length=${history.length}, message=${JSON.stringify(message)}`);
-  // Trim leading AI greetings from history before replaying
-  const trimmedHistory = [...history];
-  while (trimmedHistory.length > 0 && trimmedHistory[0].sender === 'ai') {
-    trimmedHistory.shift();
-  }
-
-  let historyForAI;
-  if (isPrimeCall) {
+  let session = getChatSession(contextId);
+  if (!session) {
     const systemPrompt = `You are a smart and friendly financial advisor who helps users understand their statements. You are well versed in Modern Portfolio Theory, Asset Allocation, Diverisification and risk management. You provide clients with clear down to earth explanations of their statments and help them identify how to optimize their portfolios.Here is the statement data:\n\n${JSON.stringify(
       context,
       null,
       2
     )}`;
-    historyForAI = [
-      { role: 'user', parts: [{ text: systemPrompt }] },
-      { role: 'model', parts: [{ text: 'Understood. I have the statement data. How can I help?' }] },
-    ];
-    console.log(`→ systemPrompt length=${systemPrompt.length}`);
-  } else {
-    historyForAI = trimmedHistory.map((msg) => ({ role: msg.sender === 'user' ? 'user' : 'model', parts: [{ text: msg.text }] }));
+    session = startChat([{ role: 'user', parts: [{ text: systemPrompt }] }]);
+    storeChatSession(contextId, session);
   }
-  console.log('→ historyForAI:', JSON.stringify(historyForAI, null, 2));
-
-  if (isPrimeCall) {
-    const chat = model.startChat({ generationConfig, safetySettings, history: historyForAI });
-    // Persist session for follow-up turns
-    storeChatSession(contextId, chat);
-    // Return the model's acknowledgment without sending a new user message
-    const greeting = historyForAI[1].parts[0].text;
-    console.log('← prime greeting:', greeting);
-    return res.status(200).json({ success: true, data: greeting });
-  }
-
-  // Follow-up: reuse existing session and stream response
-  const session = getChatSession(contextId)!;
 
   res.writeHead(200, {
     'Content-Type': 'text/event-stream',
@@ -93,7 +47,7 @@ export default createApiHandler<void>(async (
     Connection: 'keep-alive'
   });
 
-  const stream = await session.sendMessageStream(message!);
+  const stream = await sendMessageStream(session, message!);
   for await (const chunk of stream.stream) {
     const text = chunk.text();
     if (text) {
@@ -101,4 +55,5 @@ export default createApiHandler<void>(async (
     }
   }
   res.end();
+
 });


### PR DESCRIPTION
## Summary
- centralize Gemini client in `lib/gemini-service.ts`
- use service in chat and review APIs
- simplify review initialization logic and client modal

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: numerous module errors)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dc626dbf08324b0145dff20ebb30a