### PR TITLE
Fix SSE parsing and improve statement view

### DIFF
--- a/pages/dashboard/statements/[id].tsx
+++ b/pages/dashboard/statements/[id].tsx
@@ -22,10 +22,15 @@ const StatementDetailPage: NextPageWithLayout = () => {
 
   return (
     <div className="space-y-4">
-      <h1 className="text-2xl font-bold">{statement.fileName}</h1>
-      <pre className="whitespace-pre-wrap break-words bg-gray-50 p-4 rounded-md text-sm">
-        {JSON.stringify(statement.parsedData, null, 2)}
-      </pre>
+      <div className="card">
+        <h1 className="text-2xl font-bold">{statement.fileName}</h1>
+        {statement.brokerageCompany && (
+          <p className="text-sm text-gray-500">{statement.brokerageCompany}</p>
+        )}
+        <pre className="mt-4 max-h-96 overflow-auto whitespace-pre-wrap break-words rounded bg-gray-50 p-4 text-sm">
+          {JSON.stringify(statement.parsedData, null, 2)}
+        </pre>
+      </div>
     </div>
   );
 };

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -23,6 +23,7 @@ model User {
   profile          Profile?
   assets           Asset[]
   debts            Debt[]
+  statements       Statement[]
   expenseRecords   ExpenseRecord[]
   insurancePolicies InsurancePolicy[]
   financialGoals   FinancialGoal[]


### PR DESCRIPTION
## Summary
- handle multi-chunk SSE parsing in ChatInterface
- display statement details in a styled card
- define User.statements relation in Prisma schema

## Testing
- `npm run lint` *(fails: react/no-unescaped-entities and others)*
- `npm run typecheck` *(fails: multiple TS errors)*
- `npm test` *(fails: fetchSSE, statement-upload, chat tests)*

------
https://chatgpt.com/codex/tasks/task_e_6853481931cc8324bfc8a474b307b91b