### PR TITLE
Implement holistic review and statement detail improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Pocket Financial Advisor is a web application that provides personalized financi
 - Financial data input (assets, debts, expenses, insurance)
 - Goal setting and tracking
 - AI-driven insights via chat interface
+- Portfolio-wide AI review of uploaded statements
+- Detailed statement page with account and position breakdown
 - Visual dashboard with financial health metrics
 - Secure authentication with multi-factor authentication
 - PDF statement upload with Gemini's vision capabilities (supports large files via the File API)

--- a/pages/analyzer.tsx
+++ b/pages/analyzer.tsx
@@ -34,11 +34,18 @@ const AnalyzerPage: NextPageWithLayout = () => {
 
   return (
     <div>
-      <div className="flex justify-between items-center mb-6">
+      <div className="mb-6 flex items-center justify-between">
         <h1 className="text-3xl font-bold">Statement Analyzer</h1>
-        <button className="btn btn-primary" onClick={() => setIsUploadModalOpen(true)}>
-          Upload Statement
-        </button>
+        <div className="flex gap-2">
+          {statements.length > 0 && (
+            <button className="btn" onClick={() => openChat('holistic')}>
+              Overall Review
+            </button>
+          )}
+          <button className="btn btn-primary" onClick={() => setIsUploadModalOpen(true)}>
+            Upload Statement
+          </button>
+        </div>
       </div>
       <div className="space-y-4">
         {isLoading ? (

--- a/pages/dashboard/statements/[id].tsx
+++ b/pages/dashboard/statements/[id].tsx
@@ -4,21 +4,32 @@ import DashboardLayout from '../../../components/layout/DashboardLayout';
 import { fetchApi } from '../../../lib/api-utils';
 import { Statement } from '@prisma/client';
 import { NextPageWithLayout } from '../../_app';
+import { formatCurrency } from '../../../utils/format';
 
 const StatementDetailPage: NextPageWithLayout = () => {
   const router = useRouter();
   const { id } = router.query;
   const [statement, setStatement] = useState<Statement | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     if (!id || Array.isArray(id)) return;
     (async () => {
+      setIsLoading(true);
       const res = await fetchApi<Statement>(`/api/statements/${id}`);
-      if (res.success && res.data) setStatement(res.data);
+      if (res.success && res.data) {
+        setStatement(res.data);
+        setError(null);
+      } else {
+        setError(res.error || 'Failed to fetch statement');
+      }
+      setIsLoading(false);
     })();
   }, [id]);
-
-  if (!statement) return <p>Loading...</p>;
+  if (isLoading) return <p>Loading...</p>;
+  if (error) return <p className="text-red-500">Error: {error}</p>;
+  if (!statement) return null;
 
   const data: any = statement.parsedData || {};
 
@@ -36,11 +47,47 @@ const StatementDetailPage: NextPageWithLayout = () => {
       {Array.isArray(data.accounts) && data.accounts.length > 0 && (
         <div className="space-y-4">
           {data.accounts.map((acc: any, idx: number) => (
-            <div key={idx} className="rounded-md border p-4">
-              <h3 className="mb-2 font-semibold">Account {acc.name || idx + 1}</h3>
-              <pre className="whitespace-pre-wrap break-words text-sm">
-                {JSON.stringify(acc, null, 2)}
-              </pre>
+            <div key={idx} className="space-y-2 rounded-md border p-4">
+              <h3 className="font-semibold">{acc.name || `Account ${idx + 1}`}</h3>
+              {acc.type && <p className="text-sm text-gray-500">{acc.type}</p>}
+              {typeof acc.balance === 'number' && (
+                <p>Balance: {formatCurrency(acc.balance)}</p>
+              )}
+              {typeof acc.annualContribution === 'number' && (
+                <p>Annual Contribution: {formatCurrency(acc.annualContribution)}</p>
+              )}
+              {Array.isArray(acc.positions) && acc.positions.length > 0 && (
+                <div className="overflow-x-auto">
+                  <table className="min-w-full text-sm">
+                    <thead>
+                      <tr>
+                        <th className="text-left">Name</th>
+                        <th className="text-right">Quantity</th>
+                        <th className="text-right">Price</th>
+                        <th className="text-right">Value</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {acc.positions.map((pos: any, pIdx: number) => (
+                        <tr key={pIdx} className="border-t">
+                          <td>{pos.name}</td>
+                          <td className="text-right">{pos.quantity}</td>
+                          <td className="text-right">
+                            {typeof pos.price === 'number'
+                              ? formatCurrency(pos.price)
+                              : pos.price}
+                          </td>
+                          <td className="text-right">
+                            {typeof pos.value === 'number'
+                              ? formatCurrency(pos.value)
+                              : pos.value}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
             </div>
           ))}
         </div>


### PR DESCRIPTION
## Summary
- enhance statement details page with formatted account info and positions
- add holistic portfolio review button on analyzer page
- document new features in README

## Testing
- `npm run lint` *(fails: react/no-unescaped-entities and others)*
- `npm run typecheck` *(fails: TS errors in multiple files)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b68c852408324abafccc3513de4b3