### PR TITLE
Implement SSE status updates and chat panel

### DIFF
--- a/components/dashboard/ChatInterface.tsx
+++ b/components/dashboard/ChatInterface.tsx
@@ -25,10 +25,19 @@ export default function ChatInterface() {
   const { toggleChatPanel, messages, addMessage, isTyping } = useFinancialAssistant();
   const [input, setInput] = useState('');
   const messagesEndRef = useRef<HTMLDivElement>(null);
+  const [showSuggestions, setShowSuggestions] = useState(true);
 
   useEffect(() => {
     if (messagesEndRef.current) {
       messagesEndRef.current.scrollIntoView({ behavior: 'smooth' });
+    }
+  }, [messages]);
+
+  useEffect(() => {
+    if (messages.length === 1 && messages[0].sender === 'ai') {
+      setShowSuggestions(true);
+    } else if (messages.some(m => m.sender === 'user')) {
+      setShowSuggestions(false);
     }
   }, [messages]);
 
@@ -38,6 +47,7 @@ export default function ChatInterface() {
 
     const messageToSend = input;
     setInput('');
+    setShowSuggestions(false);
     await addMessage(messageToSend);
   };
 
@@ -49,7 +59,7 @@ export default function ChatInterface() {
   ];
 
   return (
-    <div className="flex h-full flex-col">
+    <div className="flex h-full max-h-[calc(100vh-7rem)] flex-col">
       <div className="border-b border-gray-200 bg-primary px-4 py-3 text-white flex justify-between items-center">
         <h3 className="text-lg font-medium">Financial Assistant</h3>
         <button onClick={toggleChatPanel} className="text-white">x</button>
@@ -71,20 +81,25 @@ export default function ChatInterface() {
         )}
         <div ref={messagesEndRef} />
       </div>
-      <div className="p-4 border-t">
-        <p className="text-xs text-gray-500 mb-2">Suggestions</p>
-        <div className="flex flex-wrap gap-2">
-          {suggestedQuestions.map(q => (
-            <button
-              key={q}
-              className="btn text-xs bg-gray-100 text-gray-700 hover:bg-gray-200"
-              onClick={() => addMessage(q)}
-            >
-              {q}
-            </button>
-          ))}
+      {showSuggestions && (
+        <div className="p-4 border-t">
+          <p className="text-xs text-gray-500 mb-2">Suggestions</p>
+          <div className="flex flex-wrap gap-2">
+            {suggestedQuestions.map(q => (
+              <button
+                key={q}
+                className="btn text-xs bg-gray-100 text-gray-700 hover:bg-gray-200"
+                onClick={() => {
+                  setShowSuggestions(false);
+                  addMessage(q);
+                }}
+              >
+                {q}
+              </button>
+            ))}
+          </div>
         </div>
-      </div>
+      )}
       <form className="border-t border-gray-200 p-4" onSubmit={handleSendMessage}>
         <div className="flex rounded-lg border border-gray-300 bg-white">
           <input

--- a/components/dashboard/ChatInterface.tsx
+++ b/components/dashboard/ChatInterface.tsx
@@ -1,6 +1,5 @@
 import { useRef, useEffect, memo, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
-import { motion, AnimatePresence } from 'framer-motion';
 import { useFinancialAssistant, Message } from '../../lib/financial-assistant-context';
 
 const MemoizedMessage = memo(function MessageComp({ message }: { message: Message }) {
@@ -23,7 +22,7 @@ const MemoizedMessage = memo(function MessageComp({ message }: { message: Messag
 });
 
 export default function ChatInterface() {
-  const { isChatOpen, closeChat, openChat, messages, addMessage, isTyping } = useFinancialAssistant();
+  const { toggleChatPanel, messages, addMessage, isTyping } = useFinancialAssistant();
   const [input, setInput] = useState('');
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
@@ -42,71 +41,64 @@ export default function ChatInterface() {
     await addMessage(messageToSend);
   };
 
-  return (
-    <>
-      <motion.button
-        className="fixed bottom-6 right-6 z-20 flex h-14 w-14 items-center justify-center rounded-full bg-primary shadow-lg hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
-        onClick={() => (isChatOpen ? closeChat() : openChat('holistic', { name: 'holistic' }))}
-        initial={{ scale: 0 }}
-        animate={{ scale: 1, rotate: isChatOpen ? 45 : 0 }}
-        transition={{ type: 'spring', stiffness: 260, damping: 20 }}
-      >
-        <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          {isChatOpen ? (
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-          ) : (
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z" />
-          )}
-        </svg>
-      </motion.button>
+  const suggestedQuestions = [
+    'Am I on track for retirement?',
+    'How can I reduce my fees?',
+    'What questions should I ask my financial advisor?',
+    'Explain my asset allocation.'
+  ];
 
-      <AnimatePresence>
-        {isChatOpen && (
-          <motion.div
-            className="fixed bottom-24 right-6 z-10 flex h-[500px] w-[350px] flex-col rounded-lg bg-white shadow-xl"
-            initial={{ opacity: 0, y: 50, scale: 0.9 }}
-            animate={{ opacity: 1, y: 0, scale: 1 }}
-            exit={{ opacity: 0, y: 50, scale: 0.9 }}
-            transition={{ type: 'spring', stiffness: 300, damping: 30 }}
-          >
-            <div className="border-b border-gray-200 bg-primary px-4 py-3 text-white flex justify-between items-center">
-              <h3 className="text-lg font-medium">Financial Assistant</h3>
-              <button onClick={closeChat} className="text-white">x</button>
-            </div>
-            <div className="flex-1 overflow-y-auto p-4">
-              {messages.map(m => (
-                <MemoizedMessage key={m.id} message={m} />
-              ))}
-              {isTyping && (
-                <div className="mb-4 flex justify-start">
-                  <div className="rounded-lg bg-gray-200 px-4 py-2 text-gray-800">
-                    <div className="flex space-x-1">
-                      <div className="h-2 w-2 animate-bounce rounded-full bg-gray-500" />
-                      <div className="h-2 w-2 animate-bounce rounded-full bg-gray-500" style={{ animationDelay: '0.2s' }} />
-                      <div className="h-2 w-2 animate-bounce rounded-full bg-gray-500" style={{ animationDelay: '0.4s' }} />
-                    </div>
-                  </div>
-                </div>
-              )}
-              <div ref={messagesEndRef} />
-            </div>
-            <form className="border-t border-gray-200 p-4" onSubmit={handleSendMessage}>
-              <div className="flex rounded-lg border border-gray-300 bg-white">
-                <input
-                  type="text"
-                  placeholder="Type your message..."
-                  className="flex-1 rounded-l-lg border-0 px-3 py-2 focus:outline-none focus:ring-0"
-                  value={input}
-                  onChange={e => setInput(e.target.value)}
-                />
-                <button type="submit" className="rounded-r-lg bg-primary px-4 py-2 text-white transition-colors hover:bg-blue-600 disabled:opacity-50" disabled={!input.trim()}>
-                  Send
-                </button>
+  return (
+    <div className="flex h-full flex-col">
+      <div className="border-b border-gray-200 bg-primary px-4 py-3 text-white flex justify-between items-center">
+        <h3 className="text-lg font-medium">Financial Assistant</h3>
+        <button onClick={toggleChatPanel} className="text-white">x</button>
+      </div>
+      <div className="flex-1 overflow-y-auto p-4">
+        {messages.map(m => (
+          <MemoizedMessage key={m.id} message={m} />
+        ))}
+        {isTyping && (
+          <div className="mb-4 flex justify-start">
+            <div className="rounded-lg bg-gray-200 px-4 py-2 text-gray-800">
+              <div className="flex space-x-1">
+                <div className="h-2 w-2 animate-bounce rounded-full bg-gray-500" />
+                <div className="h-2 w-2 animate-bounce rounded-full bg-gray-500" style={{ animationDelay: '0.2s' }} />
+                <div className="h-2 w-2 animate-bounce rounded-full bg-gray-500" style={{ animationDelay: '0.4s' }} />
               </div>
-            </form>
-          </motion.div>
+            </div>
+          </div>
         )}
-      </AnimatePresence>
-    </>
+        <div ref={messagesEndRef} />
+      </div>
+      <div className="p-4 border-t">
+        <p className="text-xs text-gray-500 mb-2">Suggestions</p>
+        <div className="flex flex-wrap gap-2">
+          {suggestedQuestions.map(q => (
+            <button
+              key={q}
+              className="btn text-xs bg-gray-100 text-gray-700 hover:bg-gray-200"
+              onClick={() => addMessage(q)}
+            >
+              {q}
+            </button>
+          ))}
+        </div>
+      </div>
+      <form className="border-t border-gray-200 p-4" onSubmit={handleSendMessage}>
+        <div className="flex rounded-lg border border-gray-300 bg-white">
+          <input
+            type="text"
+            placeholder="Type your message..."
+            className="flex-1 rounded-l-lg border-0 px-3 py-2 focus:outline-none focus:ring-0"
+            value={input}
+            onChange={e => setInput(e.target.value)}
+          />
+          <button type="submit" className="rounded-r-lg bg-primary px-4 py-2 text-white transition-colors hover:bg-blue-600 disabled:opacity-50" disabled={!input.trim()}>
+            Send
+          </button>
+        </div>
+      </form>
+    </div>
   );
 }

--- a/components/layout/DashboardLayout.tsx
+++ b/components/layout/DashboardLayout.tsx
@@ -51,7 +51,9 @@ export default function DashboardLayout({
 
         <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-6 grid grid-cols-1 lg:grid-cols-[1fr_400px] gap-6">
           <main>{children}</main>
-          <div className={`${isChatPanelVisible ? 'block' : 'hidden lg:block'}`}>
+          <div
+            className={`${isChatPanelVisible ? 'block' : 'hidden'} h-[calc(100vh-7rem)] overflow-y-auto`}
+          >
             <ChatInterface />
           </div>
         </div>

--- a/components/layout/DashboardLayout.tsx
+++ b/components/layout/DashboardLayout.tsx
@@ -4,6 +4,7 @@ import { useRouter } from 'next/router';
 import Navbar from './Navbar';
 import { useAuth } from '../../hooks/useAuth';
 import ChatInterface from '../dashboard/ChatInterface';
+import { useFinancialAssistant } from '../../lib/financial-assistant-context';
 
 type DashboardLayoutProps = {
   children: ReactNode;
@@ -15,6 +16,7 @@ export default function DashboardLayout({
   title = 'Dashboard | Pocket Financial Advisor',
 }: DashboardLayoutProps) {
   const { user, loading } = useAuth();
+  const { isChatPanelVisible } = useFinancialAssistant();
   const router = useRouter();
 
   useEffect(() => {
@@ -46,13 +48,14 @@ export default function DashboardLayout({
 
       <div className="min-h-screen bg-gray-50">
         <Navbar />
-        
-        <main className="py-6">
-          <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
-            {children}
+
+        <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-6 grid grid-cols-1 lg:grid-cols-[1fr_400px] gap-6">
+          <main>{children}</main>
+          <div className={`${isChatPanelVisible ? 'block' : 'hidden lg:block'}`}>
+            <ChatInterface />
           </div>
-        </main>
-        
+        </div>
+
         <footer className="border-t border-gray-200 bg-white py-6">
           <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
             <p className="text-center text-sm text-gray-500">
@@ -60,7 +63,6 @@ export default function DashboardLayout({
             </p>
           </div>
         </footer>
-        <ChatInterface />
       </div>
     </>
   );

--- a/components/layout/Navbar.tsx
+++ b/components/layout/Navbar.tsx
@@ -2,11 +2,13 @@ import { useState } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { useAuth } from '../../hooks/useAuth';
+import { useFinancialAssistant } from '../../lib/financial-assistant-context';
 
 export default function Navbar() {
   const [isProfileMenuOpen, setIsProfileMenuOpen] = useState(false);
   const router = useRouter();
   const { user, logout } = useAuth();
+  const { toggleChatPanel, isChatPanelVisible } = useFinancialAssistant();
 
   const handleLogout = () => {
     logout();
@@ -46,6 +48,13 @@ export default function Navbar() {
             </div>
           </div>
           <div className="hidden sm:ml-6 sm:flex sm:items-center">
+            <button
+              type="button"
+              onClick={toggleChatPanel}
+              className="mr-4 text-gray-500 hover:text-gray-700"
+            >
+              {isChatPanelVisible ? 'Hide Chat' : 'Show Chat'}
+            </button>
             <div className="relative ml-3">
               <div>
                 <button
@@ -142,6 +151,12 @@ export default function Navbar() {
           >
             Statement Analyzer
           </Link>
+          <button
+            onClick={toggleChatPanel}
+            className="block w-full text-left border-l-4 border-transparent py-2 pl-3 pr-4 text-base font-medium text-gray-600 hover:border-gray-300 hover:bg-gray-50 hover:text-gray-800"
+          >
+            {isChatPanelVisible ? 'Hide Chat' : 'Show Chat'}
+          </button>
         </div>
         <div className="border-t border-gray-200 pt-4 pb-3">
           <div className="flex items-center px-4">

--- a/lib/events.ts
+++ b/lib/events.ts
@@ -1,0 +1,3 @@
+import { EventEmitter } from 'events';
+const statementStatusEmitter = new EventEmitter();
+export default statementStatusEmitter;

--- a/lib/financial-assistant-context.tsx
+++ b/lib/financial-assistant-context.tsx
@@ -8,20 +8,20 @@ const getInitialMessage = (text?: string): Message[] => [
 ];
 
 interface FinancialAssistantState {
-  isChatOpen: boolean;
+  isChatPanelVisible: boolean;
   isTyping: boolean;
   chatMode: 'holistic' | 'statement';
   activeStatementId: string | null;
   messages: Message[];
   openChat: (mode: 'holistic' | 'statement', context: { id?: string; name?: string }) => void;
-  closeChat: () => void;
+  toggleChatPanel: () => void;
   addMessage: (text: string) => Promise<void>;
 }
 
 const FinancialAssistantContext = createContext<FinancialAssistantState | null>(null);
 
 export function FinancialAssistantProvider({ children }: { children: ReactNode }) {
-  const [isChatOpen, setIsChatOpen] = useState(false);
+  const [isChatPanelVisible, setIsChatPanelVisible] = useState(false);
   const [isTyping, setIsTyping] = useState(false);
   const [chatMode, setChatMode] = useState<'holistic' | 'statement'>('holistic');
   const [activeStatementId, setActiveStatementId] = useState<string | null>(null);
@@ -39,11 +39,11 @@ export function FinancialAssistantProvider({ children }: { children: ReactNode }
     }
     setMessages(getInitialMessage(introText));
 
-    setIsChatOpen(true);
+    setIsChatPanelVisible(true);
   };
 
-  const closeChat = () => {
-    setIsChatOpen(false);
+  const toggleChatPanel = () => {
+    setIsChatPanelVisible(prev => !prev);
   };
 
   const addMessage = async (text: string) => {
@@ -78,7 +78,7 @@ export function FinancialAssistantProvider({ children }: { children: ReactNode }
     setIsTyping(false);
   };
 
-  const value = { isChatOpen, isTyping, chatMode, activeStatementId, messages, openChat, closeChat, addMessage };
+  const value = { isChatPanelVisible, isTyping, chatMode, activeStatementId, messages, openChat, toggleChatPanel, addMessage };
 
   return (
     <FinancialAssistantContext.Provider value={value}>

--- a/pages/api/statements/status.ts
+++ b/pages/api/statements/status.ts
@@ -1,0 +1,19 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import statementStatusEmitter from '../../../lib/events';
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+    res.setHeader('Content-Type', 'text/event-stream');
+    res.setHeader('Cache-Control', 'no-cache');
+    res.setHeader('Connection', 'keep-alive');
+    res.flushHeaders();
+
+    const listener = (data: { statementId: string; status: string }) => {
+        res.write(`data: ${JSON.stringify(data)}\n\n`);
+    };
+
+    statementStatusEmitter.on('statusUpdate', listener);
+
+    req.on('close', () => {
+        statementStatusEmitter.off('statusUpdate', listener);
+    });
+}

--- a/prisma/migrations/20250626201224_added_fees_to_statement/migration.sql
+++ b/prisma/migrations/20250626201224_added_fees_to_statement/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Statement" ADD COLUMN     "totalFees" DOUBLE PRECISION;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -51,6 +51,7 @@ model Statement {
   filePath         String   @unique
   brokerageCompany String?
   parsedData       Json?
+  totalFees        Float?
   status           String   @default("PROCESSING")
   error            String?
   createdAt        DateTime @default(now())


### PR DESCRIPTION
## Summary
- add a shared `EventEmitter` and SSE endpoint for statement status
- update statement processing to emit status events and store total fees
- redesign chat interface as a sidebar with suggestions
- update layout and navbar to show/hide the chat panel
- add fees field to Prisma schema and improve fee prompts
- subscribe to SSE on the analyzer page

## Testing
- `npx next lint`
- `npm run typecheck` *(fails: Object literal may only specify known properties, TS errors)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685d969f9c948324b8afa60a015b6bd7